### PR TITLE
mockito-4.0.0-support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 <!-- ========================================================================= -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.thymeleaf</groupId>
   <artifactId>thymeleaf-testing</artifactId>
@@ -42,7 +42,7 @@
     <name>The THYMELEAF team</name>
     <url>http://www.thymeleaf.org</url>
   </organization>
-  
+
   <scm>
     <url>scm:git:git@github.com:thymeleaf/thymeleaf-testing.git</url>
     <connection>scm:git:git@github.com:thymeleaf/thymeleaf-testing.git</connection>
@@ -77,7 +77,7 @@
       </roles>
     </developer>
   </developers>
-  
+
   <distributionManagement>
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>
@@ -102,7 +102,7 @@
     </repository>
   </repositories>
 
-  
+
   <properties>
     <java.version>6</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -118,7 +118,7 @@
     <thymeleaf-spring5.version>3.0.4.M2</thymeleaf-spring5.version>
     <attoparser.version>2.0.3.RELEASE</attoparser.version>
     <servlet-api.version>3.1.0</servlet-api.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>4.0.0</mockito.version>
     <springframework.version>3.0.7.RELEASE</springframework.version>
     <springsecurity.version>3.1.2.RELEASE</springsecurity.version>
     <ognl.version>3.0.11</ognl.version>
@@ -126,15 +126,15 @@
     <slf4j.version>1.7.25</slf4j.version>
   </properties>
 
-  
+
   <build>
-  
+
     <resources>
-    
+
       <resource>
         <directory>src/main/resources</directory>
       </resource>
-    
+
       <resource>
           <directory>.</directory>
           <targetPath>META-INF</targetPath>
@@ -143,23 +143,23 @@
               <include>NOTICE.txt</include>
           </includes>
       </resource>
-      
+
     </resources>
-    
+
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>
       </testResource>
     </testResources>
-    
+
     <plugins>
-    
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
@@ -295,12 +295,12 @@
 
 
     </plugins>
-    
+
   </build>
 
 
   <dependencies>
-    
+
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
@@ -335,7 +335,7 @@
       <version>${attoparser.version}</version>
       <scope>compile</scope>
     </dependency>
-    
+
     <dependency>
         <groupId>ognl</groupId>
         <artifactId>ognl</artifactId>
@@ -362,8 +362,8 @@
       <version>${mockito.version}</version>
       <scope>compile</scope>
     </dependency>
-    
-    
+
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
@@ -392,7 +392,7 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
-    
+
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
@@ -421,22 +421,22 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
       <scope>compile</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
       <scope>compile</scope>
     </dependency>
-    
+
   </dependencies>
 
-  
+
 </project>

--- a/src/main/java/org/thymeleaf/testing/templateengine/context/web/WebProcessingContextBuilder.java
+++ b/src/main/java/org/thymeleaf/testing/templateengine/context/web/WebProcessingContextBuilder.java
@@ -1,20 +1,20 @@
 /*
  * =============================================================================
- * 
+ *
  *   Copyright (c) 2011-2016, The THYMELEAF team (http://www.thymeleaf.org)
- * 
+ *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
- * 
+ *
  * =============================================================================
  */
 package org.thymeleaf.testing.templateengine.context.web;
@@ -41,7 +41,8 @@ import javax.servlet.http.HttpSession;
 import ognl.Ognl;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.mockito.Matchers;
+import org.mockito.ArgumentArgumentMatchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -66,69 +67,69 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
     private static final String SESSION_ATTRS_PREFIX = "session";
     private static final String SERVLETCONTEXT_ATTRS_PREFIX = "application";
 
-    
 
-    
+
+
     public WebProcessingContextBuilder() {
         super();
     }
-    
-    
-    
+
+
+
     @SuppressWarnings("unchecked")
     public final IContext build(final ITest test) {
-        
+
         if (test == null) {
             return null;
         }
-        
+
         final ITestContext testContext = test.getContext();
-        
+
         Locale locale = DEFAULT_LOCALE;
         final ITestContextExpression localeExpression = testContext.getLocale();
         if (localeExpression != null) {
-            final Object exprResult = 
+            final Object exprResult =
                     localeExpression.evaluate(Collections.EMPTY_MAP, DEFAULT_LOCALE);
             if (exprResult != null) {
                 locale = LocaleUtils.toLocale(exprResult.toString());
             }
         }
-        
-        
+
+
         final Map<String,Object> variables = new HashMap<String, Object>();
-        
+
         final Map<String,Object[]> requestParameters = new LinkedHashMap<String, Object[]>();
         variables.put(REQUEST_PARAMS_PREFIX, requestParameters);
-        
+
         final Map<String,Object> requestAttributes = new LinkedHashMap<String, Object>();
         variables.put(REQUEST_ATTRS_PREFIX, requestAttributes);
-        
+
         final Map<String,Object> sessionAttributes = new LinkedHashMap<String, Object>();
         variables.put(SESSION_ATTRS_PREFIX, sessionAttributes);
-        
+
         final Map<String,Object> servletContextAttributes = new LinkedHashMap<String, Object>();
         variables.put(SERVLETCONTEXT_ATTRS_PREFIX, servletContextAttributes);
 
-        
+
         for (final Map.Entry<String,ITestContextExpression> entry : testContext.getVariables().entrySet()) {
             resolve(entry.getKey(), entry.getValue(), variables, locale);
         }
         for (final Map.Entry<String,ITestContextExpression[]> entry : testContext.getRequestParameters().entrySet()) {
-            
+
             final int firstPoint = entry.getKey().indexOf('.');
             final String paramName =
                     (firstPoint == -1? entry.getKey() : entry.getKey().substring(0, firstPoint));
-            final String remainder = 
+            final String remainder =
                     (firstPoint == -1? "" : entry.getKey().substring(firstPoint));
             final Object[] paramValues = new Object[entry.getValue().length];
-            
+
             requestParameters.put(paramName, paramValues); // We initialize an array long enough to hold all the values.
 
             final int expressionsLen = entry.getValue().length;
             for (int i = 0; i < expressionsLen; i++) {
                 resolve((REQUEST_PARAMS_PREFIX + "." + paramName + "[" + i + "]" + remainder), entry.getValue()[i], variables, locale);
             }
-            
+
         }
         for (final Map.Entry<String,ITestContextExpression> entry : testContext.getRequestAttributes().entrySet()) {
             resolve(REQUEST_ATTRS_PREFIX + "." + entry.getKey(), entry.getValue(), variables, locale);
@@ -139,31 +140,31 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
         for (final Map.Entry<String,ITestContextExpression> entry : testContext.getServletContextAttributes().entrySet()) {
             resolve(SERVLETCONTEXT_ATTRS_PREFIX + "." + entry.getKey(), entry.getValue(), variables, locale);
         }
-        
-        
+
+
         final ServletContext servletContext = createMockServletContext(servletContextAttributes);
         final HttpSession session = createMockHttpSession(servletContext, sessionAttributes);
         final HttpServletRequest request = createMockHttpServletRequest(test, session, requestAttributes, requestParameters, locale);
         final HttpServletResponse response = createMockHttpServletResponse();
-        
+
         variables.remove(REQUEST_PARAMS_PREFIX);
         variables.remove(REQUEST_ATTRS_PREFIX);
         variables.remove(SESSION_ATTRS_PREFIX);
         variables.remove(SERVLETCONTEXT_ATTRS_PREFIX);
 
         doAdditionalVariableProcessing(test, request, response, servletContext, locale, variables);
-        
+
         final IWebContext context =
                 doCreateWebContextInstance(test, request, response, servletContext, locale, variables);
-        
+
         return context;
-        
+
     }
 
 
     @SuppressWarnings("unused")
     protected void doAdditionalVariableProcessing(
-            final ITest test, 
+            final ITest test,
             final HttpServletRequest request, final HttpServletResponse response, final ServletContext servletContext,
             final Locale locale, final Map<String,Object> variables) {
         // Nothing to be done here, meant to be overriden
@@ -178,9 +179,9 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
         return new WebContext(request, response, servletContext, locale, variables);
     }
 
-    
-    
-    
+
+
+
     static final HttpServletRequest createMockHttpServletRequest(
             final ITest test,
             final HttpSession session, final Map<String, Object> attributes,
@@ -200,7 +201,7 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
         final String queryString = buildQueryString(parameters);
         final int contentLength = -1; // -1 is HTTP standard for 'unknown'
         final Enumeration<String> headerNames = new ObjectEnumeration<String>(null);
-        
+
         final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 
         Mockito.when(request.getContentType()).thenReturn(mimeType);
@@ -221,45 +222,45 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
         Mockito.when(request.getHeaderNames()).thenReturn(headerNames);
 
         Mockito.when(request.getSession()).thenReturn(session);
-        Mockito.when(request.getSession(Matchers.anyBoolean())).thenReturn(session);
+        Mockito.when(request.getSession(ArgumentMatchers.anyBoolean())).thenReturn(session);
 
         Mockito.when(request.getAttributeNames()).thenAnswer(new GetVariableNamesAnswer(attributes));
-        Mockito.when(request.getAttribute(Matchers.anyString())).thenAnswer(new GetAttributeAnswer(attributes));
-        Mockito.doAnswer(new SetAttributeAnswer(attributes)).when(request).setAttribute(Matchers.anyString(), Matchers.anyObject());
-        Mockito.doAnswer(new RemoveAttributeAnswer(attributes)).when(request).removeAttribute(Matchers.anyString());
+        Mockito.when(request.getAttribute(ArgumentMatchers.anyString())).thenAnswer(new GetAttributeAnswer(attributes));
+        Mockito.doAnswer(new SetAttributeAnswer(attributes)).when(request).setAttribute(ArgumentMatchers.anyString(), ArgumentMatchers.any());
+        Mockito.doAnswer(new RemoveAttributeAnswer(attributes)).when(request).removeAttribute(ArgumentMatchers.anyString());
 
         Mockito.when(request.getParameterNames()).thenAnswer(new GetVariableNamesAnswer(parameters));
-        Mockito.when(request.getParameterValues(Matchers.anyString())).thenAnswer(new GetParameterValuesAnswer(parameters));
+        Mockito.when(request.getParameterValues(ArgumentMatchers.anyString())).thenAnswer(new GetParameterValuesAnswer(parameters));
         Mockito.when(request.getParameterMap()).thenAnswer(new GetParameterMapAnswer(parameters));
-        Mockito.when(request.getParameter(Matchers.anyString())).thenAnswer(new GetParameterAnswer(parameters));
+        Mockito.when(request.getParameter(ArgumentMatchers.anyString())).thenAnswer(new GetParameterAnswer(parameters));
 
-        
+
         return request;
-        
+
     }
 
 
 
     static final HttpSession createMockHttpSession(final ServletContext context, final Map<String, Object> attributes) {
-        
+
         final HttpSession session = Mockito.mock(HttpSession.class);
-        
+
         Mockito.when(session.getServletContext()).thenReturn(context);
 
         Mockito.when(session.getAttributeNames()).thenAnswer(new GetVariableNamesAnswer(attributes));
-        Mockito.when(session.getAttribute(Matchers.anyString())).thenAnswer(new GetAttributeAnswer(attributes));
-        Mockito.doAnswer(new SetAttributeAnswer(attributes)).when(session).setAttribute(Matchers.anyString(), Matchers.anyObject());
-        Mockito.doAnswer(new RemoveAttributeAnswer(attributes)).when(session).removeAttribute(Matchers.anyString());
+        Mockito.when(session.getAttribute(ArgumentMatchers.anyString())).thenAnswer(new GetAttributeAnswer(attributes));
+        Mockito.doAnswer(new SetAttributeAnswer(attributes)).when(session).setAttribute(ArgumentMatchers.anyString(), ArgumentMatchers.any());
+        Mockito.doAnswer(new RemoveAttributeAnswer(attributes)).when(session).removeAttribute(ArgumentMatchers.anyString());
 
         return session;
-        
+
     }
 
 
 
     static final HttpServletResponse createMockHttpServletResponse() {
         final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-        Mockito.when(response.encodeURL(Matchers.anyString())).thenAnswer(new EncodeUrlAnswer());
+        Mockito.when(response.encodeURL(ArgumentMatchers.anyString())).thenAnswer(new EncodeUrlAnswer());
         return response;
     }
 
@@ -272,27 +273,27 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
         final ServletContext servletContext = Mockito.mock(ServletContext.class);
         
         Mockito.when(servletContext.getAttributeNames()).thenAnswer(new GetVariableNamesAnswer(attributes));
-        Mockito.when(servletContext.getAttribute(Matchers.anyString())).thenAnswer(new GetAttributeAnswer(attributes));
-        Mockito.doAnswer(new SetAttributeAnswer(attributes)).when(servletContext).setAttribute(Matchers.anyString(), Matchers.anyObject());
-        Mockito.doAnswer(new RemoveAttributeAnswer(attributes)).when(servletContext).removeAttribute(Matchers.anyString());
+        Mockito.when(servletContext.getAttribute(ArgumentMatchers.anyString())).thenAnswer(new GetAttributeAnswer(attributes));
+        Mockito.doAnswer(new SetAttributeAnswer(attributes)).when(servletContext).setAttribute(ArgumentMatchers.anyString(), ArgumentMatchers.any());
+        Mockito.doAnswer(new RemoveAttributeAnswer(attributes)).when(servletContext).removeAttribute(ArgumentMatchers.anyString());
         Mockito.when(servletContext.getContextPath()).thenReturn(contextName);
 
         Mockito.when(servletContext.getInitParameterNames()).thenReturn(new ObjectEnumeration<String>(null));
-        Mockito.when(servletContext.getInitParameter(Matchers.anyString())).thenReturn(null);
-        
+        Mockito.when(servletContext.getInitParameter(ArgumentMatchers.anyString())).thenReturn(null);
+
         return servletContext;
     }
-    
 
-    
-    
-    
-    
-    
+
+
+
+
+
+
     private static class ObjectEnumeration<T> implements Enumeration<T> {
 
         private final Iterator<T> iterator;
-        
+
         @SuppressWarnings("unchecked")
         public ObjectEnumeration(final Collection<T> values) {
             super();
@@ -302,7 +303,7 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
                 this.iterator = ((List<T>)Collections.emptyList()).iterator();
             }
         }
-        
+
         public boolean hasMoreElements() {
             return this.iterator.hasNext();
         }
@@ -310,56 +311,56 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
         public T nextElement() {
             return this.iterator.next();
         }
-        
-    }
-    
 
-    
-    
+    }
+
+
+
+
     private static class GetVariableNamesAnswer implements Answer<Enumeration<?>> {
 
         private final Map<String,?> values;
-        
+
         public GetVariableNamesAnswer(final Map<String,?> values) {
             super();
             this.values = values;
         }
-        
+
         public Enumeration<?> answer(final InvocationOnMock invocation) throws Throwable {
             return new ObjectEnumeration<String>(this.values.keySet());
         }
-        
+
     }
-    
-    
-    
+
+
+
     private static class GetAttributeAnswer implements Answer<Object> {
 
         private final Map<String,Object> values;
-        
+
         public GetAttributeAnswer(final Map<String,Object> values) {
             super();
             this.values = values;
         }
-        
+
         public Object answer(final InvocationOnMock invocation) throws Throwable {
             final String attributeName = (String) invocation.getArguments()[0];
             return this.values.get(attributeName);
         }
-        
+
     }
-    
-    
-    
+
+
+
     private static class SetAttributeAnswer implements Answer<Object> {
 
         private final Map<String,Object> values;
-        
+
         public SetAttributeAnswer(final Map<String,Object> values) {
             super();
             this.values = values;
         }
-        
+
         public Object answer(final InvocationOnMock invocation) throws Throwable {
             final String attributeName = (String) invocation.getArguments()[0];
             final Object attributeValue = invocation.getArguments()[1];
@@ -371,7 +372,7 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
             }
             return null;
         }
-        
+
     }
 
 
@@ -393,17 +394,17 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
 
     }
 
-    
-    
+
+
     private static class GetParameterValuesAnswer implements Answer<String[]> {
 
         private final Map<String,Object[]> values;
-        
+
         public GetParameterValuesAnswer(final Map<String,Object[]> values) {
             super();
             this.values = values;
         }
-        
+
         public String[] answer(final InvocationOnMock invocation) throws Throwable {
             final String parameterName = (String) invocation.getArguments()[0];
             final Object[] parameterValues = this.values.get(parameterName);
@@ -417,20 +418,20 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
             }
             return parameterValuesArray;
         }
-        
+
     }
-    
-    
-    
+
+
+
     private static class GetParameterAnswer implements Answer<String> {
 
         private final Map<String,Object[]> values;
-        
+
         public GetParameterAnswer(final Map<String,Object[]> values) {
             super();
             this.values = values;
         }
-        
+
         public String answer(final InvocationOnMock invocation) throws Throwable {
             final String parameterName = (String) invocation.getArguments()[0];
             final Object[] parameterValues = this.values.get(parameterName);
@@ -440,20 +441,20 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
             final Object value = parameterValues[0];
             return (value == null? null : value.toString());
         }
-        
+
     }
-    
-    
-    
+
+
+
     private static class GetParameterMapAnswer implements Answer<Map<String,String[]>> {
 
         private final Map<String,Object[]> values;
-        
+
         public GetParameterMapAnswer(final Map<String,Object[]> values) {
             super();
             this.values = values;
         }
-        
+
         public Map<String,String[]> answer(final InvocationOnMock invocation) throws Throwable {
             final Map<String,String[]> parameterMap = new HashMap<String, String[]>();
             for (final Map.Entry<String,Object[]> valueEntry : this.values.entrySet()) {
@@ -472,31 +473,31 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
             }
             return parameterMap;
         }
-        
-    }
-    
 
-    
+    }
+
+
+
     private static class EncodeUrlAnswer implements Answer<String> {
 
         public EncodeUrlAnswer() {
             super();
         }
-        
+
         public String answer(final InvocationOnMock invocation) throws Throwable {
             return (String) invocation.getArguments()[0];
         }
-        
+
     }
-    
-    
+
+
 
     private static void resolve(final String expression, final ITestContextExpression contextExpression, final Map<String,Object> variables, final Locale locale) {
-        
+
         try {
-            
+
             final Object result = contextExpression.evaluate(variables, locale);
-            
+
             final Object parsedExpression = Ognl.parseExpression(expression);
             Ognl.setValue(parsedExpression, variables, result);
 
@@ -504,13 +505,13 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
             throw new TestEngineExecutionException(
                     "Exception while trying to evaluate expression \"" +  expression + "\" on context for test \"" + TestExecutor.getThreadTestName() + "\"", t);
         }
-        
+
     }
 
-    
-    
+
+
     private static String testNameToServletPath(final String testName) {
-        
+
         String normalizedName = StringUtils.stripAccents(testName);
         if (normalizedName.contains("/")) {
             normalizedName = normalizedName.substring(normalizedName.lastIndexOf('/'));
@@ -518,11 +519,11 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
         if (normalizedName.contains("\\")) {
             normalizedName = normalizedName.substring(normalizedName.lastIndexOf('\\'));
         }
-        
+
         if (normalizedName.endsWith(".thtest")) {
             normalizedName = normalizedName.substring(0, normalizedName.length() - 7);
         }
-        
+
         final StringBuilder strBuilder = new StringBuilder();
         final int nameLen = normalizedName.length();
         for (int i = 0; i < nameLen; i++) {
@@ -533,17 +534,17 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
         }
         return strBuilder.toString();
     }
-    
-    
+
+
     private static String buildQueryString(final Map<String,Object[]> parameters) {
-        
+
         if (parameters == null || parameters.size() == 0) {
             return null;
         }
-        
+
         final StringBuilder strBuilder = new StringBuilder();
         for (final Map.Entry<String,Object[]> parameterEntry : parameters.entrySet()) {
-            
+
             final String parameterName = parameterEntry.getKey();
             final Object[] parameterValues = parameterEntry.getValue();
 
@@ -554,7 +555,7 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
                 strBuilder.append(parameterName);
                 continue;
             }
-            
+
             for (final Object parameterValue : parameterValues) {
                 if (strBuilder.length() > 0) {
                     strBuilder.append('&');
@@ -567,16 +568,16 @@ public class WebProcessingContextBuilder implements IProcessingContextBuilder {
                     } catch (final UnsupportedEncodingException e) {
                         // Should never happen, UTF-8 just exists.
                         throw new RuntimeException(e);
-                    } 
+                    }
                 }
             }
-            
+
         }
-        
+
         return strBuilder.toString();
-        
+
     }
-    
-    
-    
+
+
+
 }


### PR DESCRIPTION
Hello thymeleaf-testing maintainers,
I'm adding a PR here hoping this is a simple update (and possible patch release), but as someone not involved in the project I could be totally off base, not considering things already in the pipeline, etc.
I use this testing library in a couple of work projects, and am blocked from updating to Spring-Boot 2.6.5 due to the deprecated `org.mockito.Matchers` references.  [See open issue: Support for Mockito 4](https://github.com/thymeleaf/thymeleaf-testing/issues/23) - #23 

I did read through the contribution docs, but please correct me if I missed something.  Thank you!

_____
* Update version of mockito from 1.10.19 to 4.0.0. Replace use of deprecated mockito Matchers with ArgumentMatchers.